### PR TITLE
Remove FZF_COLOR_SCHEME for Nord

### DIFF
--- a/roles/fzf/.zsh.d/fzf.zshrc.env
+++ b/roles/fzf/.zsh.d/fzf.zshrc.env
@@ -1,7 +1,2 @@
-# https://github.com/junegunn/fzf/wiki/Color-schemes#nord
-FZF_COLOR_SCHEME='
---color fg:#D8DEE9,bg:#2E3440,hl:#A3BE8C,fg+:#D8DEE9,bg+:#434C5E,hl+:#A3BE8C
---color pointer:#BF616A,info:#4C566A,spinner:#4C566A,header:#4C566A,prompt:#81A1C1,marker:#EBCB8B
-'
-export FZF_DEFAULT_OPTS="$FZF_COLOR_SCHEME -0 --inline-info --cycle" 
+export FZF_DEFAULT_OPTS="-0 --inline-info --cycle" 
 


### PR DESCRIPTION
## Overview
この設定をすると、逆に意図しないカラーになるので削除した。
Terminal Nord の Color をすでに設定しているため競合しているのかもしれない（調べてはいない）。

refs. https://github.com/junegunn/fzf/wiki/Color-schemes#nord

上記 URL の通り設定すると、こんな風になるが、
<img width="487" alt="Screen Shot 2022-02-23 at 18 51 50" src="https://user-images.githubusercontent.com/89905739/155296296-547f6df2-e6c0-4a6e-87ea-abc0385a15a4.png">

FZF_COLOR_SCHEME を外すと、意図した色になった。
<img width="710" alt="Screen Shot 2022-02-23 at 18 53 16" src="https://user-images.githubusercontent.com/89905739/155296346-2f276426-3f0e-49fe-8024-9f0156c5eb20.png">
