### PR TITLE
Add a method to install by specifying a role

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ make install
 
 # by ROLE
 make install ROLE=vim
+
+# Only specified ROLES
+export DOTF_ROLES_FILE=`pwd`/roles.txt
+cat $DOTF_ROLES_FILE
+# is a comment, blank lines are ignored.
+fzf
+git
+tig
+make install
 ```
 
 

--- a/_tools/install_all.sh
+++ b/_tools/install_all.sh
@@ -10,7 +10,16 @@ timestamp() {
 
 main() {
   local roles role_path role
-  roles=$(find roles ! -path './_tools*' -a ! -path './.git*' -a -name 'install.sh' | sort)
+
+  if [[ -f $DOTF_ROLES_FILE ]]; then
+    while read role; do
+      [[ $role =~ ^# ]] && continue
+      roles="$roles $role"
+    done < <(cat $DOTF_ROLES_FILE) 
+    roles=$(echo "${roles}" | tr ' ' '\n' | sed '/^$/d' | sort | uniq)
+  else
+    roles=$(find roles ! -path './_tools*' -a ! -path './.git*' -a -name 'install.sh' | sort)
+  fi
 
   echo "$(timestamp) [INFO] Install roles list"
   echo ${roles} | sed -E 's/roles\/|\/install.sh//g' | tr ' ' '\n'


### PR DESCRIPTION
## Overview
環境変数 DOTF_ROLES_FILE が設定されている場合、そのファイルに列挙されている role のみインストールできるようにした。


### Usage
```
% export DOTF_ROLES_FILE=`pwd`/roles.txt
% cat $DOTF_ROLES_FILE
# is a comment, blank lines are ignored.
zsh
fzf
git

# dropbox
tig

% curl -fsSL https://raw.githubusercontent.com/onigiri10co/dotfiles/HEAD/install.sh | zsh
2022-02-23 20:59:51 [INFO] Install roles list
fzf
git
tig
zsh
2022-02-23 20:59:51 [INFO] Install fzf...
...
```



## ToDo
- Wiki に、仕事用の role リストを記載しておく（dropbox 除くなど）。
