### PR TITLE
Refactor: change macvim installer place from default to cask

### DIFF
--- a/roles/macvim/install.sh
+++ b/roles/macvim/install.sh
@@ -2,15 +2,7 @@
 set -e
 
 
-brew list macvim > /dev/null 2>&1 || {
-  brew install macvim
+brew list --cask macvim > /dev/null 2>&1 || {
+  brew install macvim --cask
 }
 
-MACVIM_ABSOLUTE_ROOT_PATH="$(readlink -f $(brew --prefix macvim))"
-MACVIM_ABSOLUTE_PATH="${MACVIM_ABSOLUTE_ROOT_PATH}/MacVim.app"
-
-# ref. https://newbedev.com/macvim-is-not-found-by-spotlight
-if [[ ! -L ${MACVIM_ABSOLUTE_PATH} && -e ${MACVIM_ABSOLUTE_PATH} ]]; then
-  mv -f ${MACVIM_ABSOLUTE_PATH} /Applications/
-  ln -fs /Applications/MacVim.app ${MACVIM_ABSOLUTE_ROOT_PATH}/
-fi


### PR DESCRIPTION
--cask の macvim　をインストールすれば、/Applications への mv や、vim binary へのリンクを自動でやってくれる。
なので、（brew install macvim から）こっちに変更し、自前で実施していた /Applications への mv などの処理は削除した。

<img width="674" alt="Screen Shot 2022-02-24 at 17 10 49" src="https://user-images.githubusercontent.com/89905739/155494540-2b876852-3cee-4dc5-8dd0-fb241c7c0ca4.png">
