### PR TITLE
fix: export PATH for MacVim Troubleshooting

### DIFF
--- a/roles/macvim/.zprofile
+++ b/roles/macvim/.zprofile
@@ -1,0 +1,11 @@
+# NOTE: 
+# 基本的に ~/.zshrc に全て定義しており、~/.zprofile は使用しない方針であったが、以下の対応で必要になったので、MacVim スペシャル対応として作成する。
+# refs. https://github.com/macvim-dev/macvim/wiki/Troubleshooting#for-zsh-users
+#
+# 他で必要になったら、競合するため、そのときにどうするか改めて考える。
+#
+# 本来は、PATH だけ記載すれば良いのだが、以下の理由で色々こねくり回すのと無駄にややこしくなるので、いっそ全て source している（問題が出たら、その時改めて考える）。
+# - MacVim インストール時のタイミングで、PATH を grep してしまうと、まだ完成していない PATH になってしまう
+# - ~/.zsh.d/.zshrc まで考慮する必要がある
+#
+source ~/.zshrc

--- a/roles/macvim/README.md
+++ b/roles/macvim/README.md
@@ -1,2 +1,7 @@
 # roles/macvim
 
+
+
+### Tips: MacVim 起動時に PATH を通すため、~/.zprofile を定義している。
+- See [Troubleshooting > for-zsh-users macvim-dev/macvim Wiki](https://github.com/macvim-dev/macvim/wiki/Troubleshooting#for-zsh-users)
+

--- a/roles/macvim/install.sh
+++ b/roles/macvim/install.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env zsh
 set -e
 
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+
 
 brew list --cask macvim > /dev/null 2>&1 || {
   brew install macvim --cask
 }
+
+( 
+cd ${CURRENT_PATH}
+cp -f .zprofile ${HOME}
+)
 


### PR DESCRIPTION
See: https://github.com/macvim-dev/macvim/wiki/Troubleshooting#for-zsh-users

https://github.com/onigiri10co/dotfiles/pull/11/files#diff-3c39234ce8c226fcd663685f17c14a107c4466166384731c15577a84d4ce560d
> NOTE: 
> 基本的に ~/.zshrc に全て定義しており、~/.zprofile は使用しない方針であったが、以下の対応で必要になったので、MacVim スペシャル対応として作成する。
> refs. https://github.com/macvim-dev/macvim/wiki/Troubleshooting#for-zsh-users
> 
> 他で必要になったら、競合するため、そのときにどうするか改めて考える。
> 
> 本来は、PATH だけ記載すれば良いのだが、以下の理由で色々こねくり回すのと無駄にややこしくなるので、いっそ全て source している（問題が出たら、その時改めて考える）。
> - MacVim インストール時のタイミングで、PATH を grep してしまうと、まだ完成していない PATH になってしまう
> - ~/.zsh.d/.zshrc まで考慮する必要がある ← この辺がめんどくさい
> 
> source ~/.zshrc

