### PR TITLE
Add vim-quickrun

### DIFF
--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -115,6 +115,7 @@ Plug 'prabirshrestha/asyncomplete-lsp.vim'
 Plug 'hrsh7th/vim-vsnip'
 Plug 'hrsh7th/vim-vsnip-integ'
 Plug 'rafamadriz/friendly-snippets'
+Plug 'thinca/vim-quickrun'
 call plug#end()
 
 
@@ -295,6 +296,16 @@ function! s:vista_keymap()
   nmap <silent><buffer> <ESC><ESC> :<C-u>Vista!<CR>
   imap <silent><buffer> <ESC><ESC> <ESC>:<C-u>Vista!<CR>
 endfunction
+
+
+"Setting/Tool/thinca/vim-quickrun
+nnoremap <silent><Leader>q :QuickRun<CR>
+let g:quickrun_config = {
+\  "_": {
+\    "outputter": "quickfix",
+\    "hook/time/enable":  1
+\  },
+\}
 
 
 "Setting/Tool/itchyny/lightline.vim


### PR DESCRIPTION
## 設定一覧
- キーマップ: Leader q で、QuickRun を実行する
- "outputter": "quickfix"  "結果を QuickFix に表示する
- "hook/time/enable": 1 "実行時間を表示する


## References
- デフォルト設定: https://github.com/thinca/vim-quickrun/blob/4f2f5628098efba5db2ae152dc3ac0d9b310659a/autoload/quickrun.vim#L21
- 設定参考: https://osyo-manga.hatenadiary.org/entry/20130311/1363012363
