### PR TITLE
add efm langserver with python settings

### DIFF
--- a/roles/efm-langserver/.config/config.yaml
+++ b/roles/efm-langserver/.config/config.yaml
@@ -1,4 +1,6 @@
 version: 2
+root-markers:
+  - .git/
 # log-file: ./efm-langserver.log
 # log-level: 1
 

--- a/roles/efm-langserver/.config/config.yaml
+++ b/roles/efm-langserver/.config/config.yaml
@@ -1,0 +1,35 @@
+version: 2
+# log-file: ./efm-langserver.log
+# log-level: 1
+
+
+tools:
+  python-flake8: &python-flake8
+    lint-command: 'poetry run flake8 --stdin-display-name ${INPUT} -'
+    lint-stdin: true
+    lint-formats:
+      - '%f:%l:%c: %m'
+
+  python-mypy: &python-mypy
+    lint-command: 'poetry run mypy --show-column-numbers'
+    lint-formats:
+      - '%f:%l:%c: %trror: %m'
+      - '%f:%l:%c: %tarning: %m'
+      - '%f:%l:%c: %tote: %m'
+
+  python-black: &python-black
+    format-command: 'poetry run black --quiet -'
+    format-stdin: true
+
+  python-isort: &python-isort
+    format-command: 'poetry run isort --quiet -'
+    format-stdin: true
+
+
+languages:
+  python:
+    - <<: *python-flake8
+    - <<: *python-mypy
+    - <<: *python-black
+    - <<: *python-isort
+

--- a/roles/efm-langserver/.config/config.yaml
+++ b/roles/efm-langserver/.config/config.yaml
@@ -1,6 +1,7 @@
 version: 2
 root-markers:
   - .git/
+lint-debounce: 1s
 # log-file: ./efm-langserver.log
 # log-level: 1
 

--- a/roles/efm-langserver/.zsh.d/efm-langserver.zshrc.env
+++ b/roles/efm-langserver/.zsh.d/efm-langserver.zshrc.env
@@ -1,0 +1,1 @@
+export XDG_CONFIG_HOME=$HOME/.config

--- a/roles/efm-langserver/README.md
+++ b/roles/efm-langserver/README.md
@@ -1,0 +1,3 @@
+# roles/efm-langserver
+- [mattn/efm-langserver: General purpose Language Server](https://github.com/mattn/efm-langserver)
+

--- a/roles/efm-langserver/dependencies
+++ b/roles/efm-langserver/dependencies
@@ -1,0 +1,1 @@
+homebrew

--- a/roles/efm-langserver/install.sh
+++ b/roles/efm-langserver/install.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+set -e
+
+readonly CURRENT_PATH=$(cd $(dirname $0); pwd)
+
+
+brew list efm-langserver > /dev/null 2>&1 || {
+  brew install efm-langserver
+}
+
+( 
+cd ${CURRENT_PATH}
+cp -fr .zsh.d ${HOME}/
+cp -fr .config ${HOME}/
+)
+

--- a/roles/python/README.md
+++ b/roles/python/README.md
@@ -1,4 +1,5 @@
 # roles/python
+[Python](https://github.com/python/)
 
 
 
@@ -44,7 +45,7 @@
  3.11-dev
 ```
 
-※README には、`eval "$(pyenv init -)"` とあるが、`eval "$(pyenv init --path)"` にしないとシステムデフォルトの Python を参照するため、こうしている。
+NOTE: README には、`eval "$(pyenv init -)"` とあるが、`eval "$(pyenv init --path)"` にしないとシステムデフォルトの Python を参照するため、こうしている。
 
 
 ### Install pipx
@@ -56,7 +57,7 @@
 % brew install pipx
 ```
 
-※`pipx ensurepath` でも良いが、~/.zshrc などに自動的に PATH が書き込まれるため、自前で制御したければ上記のように設定する。
+NOTE: `pipx ensurepath` でも良いが、~/.zshrc などに自動的に PATH が書き込まれるため、自前で制御したければ上記のように設定する。
 
 
 ### Install poetry
@@ -83,24 +84,69 @@ virtualenvs.in-project = true に設定しても、既に virtualenvs.path 配�
 ```
 % pyenv install 3.10.2
 % poetry new example; cd $_;
-Created package example3 in example3
+Created package example in example
 % pyenv local 3.10.2
 % python -V
 Python 3.10.2
+% poetry add flake8 mypy black isort -D
 ```
 
 
+### サンプルプログラム
+```
+% cat << EOF > example/fizzbuzz.py
+def main():
+    for i in range(1, 101):
+        print(fizz_buzz(i))
 
----
-# TODO: 以下もいずれ追記する。
 
-- フォーマッター、リンター設定
-  - vim efm-lsp の設定で、効かせるようにする
-- サンプルプログラム作成
-- そのまま実行
-  - vim quickrun の設定
-- テストプログラム作成
-- テスト実行
-  - vim-test ?
-  - vim quickrun の設定？
+def fizz_buzz(num: int) -> str:
+    if num % 3 == 0 and num % 5 == 0:
+        return "FizzBuzz"
+    elif num % 3 == 0:
+        return "Fizz"
+    elif num % 5 == 0:
+        return "Buzz"
+    else:
+        return str(num)
+
+
+if __name__ == "__main__":
+    main()
+
+EOF
+
+% poetry run python example/fizzbuzz.py
+```
+
+NOTE: vim からは、:QuickRun poetry で実行できる。
+
+
+### サンプルプログラムテスト
+```
+cat << EOF > tests/test_fizzbuzz.py
+def test_fizz_buzz():
+    from example.fizzbuzz import fizz_buzz
+
+    assert fizz_buzz(1) == "1"
+    assert fizz_buzz(2) == "2"
+    assert fizz_buzz(3) == "Fizz"
+    assert fizz_buzz(4) == "4"
+    assert fizz_buzz(5) == "Buzz"
+    assert fizz_buzz(10) == "Buzz"
+    assert fizz_buzz(15) == "FizzBuzz"
+    assert fizz_buzz(75) == "FizzBuzz"
+    assert fizz_buzz(83) == "83"
+    assert fizz_buzz(99) == "Fizz"
+    assert fizz_buzz(100) == "Buzz"
+
+EOF
+
+% poetry run pytest tests/test_fizzbuzz.py
+```
+
+
+NOTE: vim からは、:QuickRun poetry/pytest or \<Leader-r\> で実行できる。 Python 周りの vim の設定は、以下の PR を参照。
+
+- [add efm langserver with python settings by onigiri10co · Pull Request #19 · onigiri10co/dotfiles](https://github.com/onigiri10co/dotfiles/pull/19)
 

--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -119,6 +119,7 @@ Plug 'tyru/open-browser.vim'
 ""Development
 Plug 'prabirshrestha/vim-lsp'
 Plug 'mattn/vim-lsp-settings'
+Plug 'mattn/efm-langserver'
 Plug 'liuchengxu/vista.vim'
 Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/asyncomplete-lsp.vim'
@@ -273,6 +274,11 @@ command! LspDebug let lsp_log_verbose=1 | let lsp_log_file = expand('~/lsp.log')
 
 let g:lsp_signs_enabled = 1
 let g:lsp_diagnostics_echo_cursor = 1
+let g:lsp_settings = {
+\   'efm-langserver': {
+\     'disabled': v:false
+\   },
+\ }
 let g:asyncomplete_auto_popup = 0
 let g:vsnip_snippet_dir = expand($XDG_CONFIG_HOME . '/vsnip')
 

--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -279,6 +279,22 @@ let g:lsp_settings = {
 \   'efm-langserver': {
 \     'disabled': v:false
 \   },
+\   'pylsp-all': {
+\     'workspace_config': {
+\       'pylsp': {
+\         'plugins': {
+\           'flake8': { 'enabled': v:false },
+\           'pycodestyle': { 'enabled': v:false },
+\           'pydocstyle': { 'enabled': v:false },
+\           'autopep8': { 'enabled': v:false },
+\           'pyflakes': { 'enabled': v:false },
+\           'pylint': { 'enabled': v:false },
+\           'mccabe': { 'enabled': v:false },
+\           'yapf': { 'enabled': v:false },
+\         }
+\       }
+\     }
+\   }
 \ }
 let g:asyncomplete_auto_popup = 0
 let g:vsnip_snippet_dir = expand($XDG_CONFIG_HOME . '/vsnip')

--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -268,6 +268,7 @@ augroup LSPSettings
   autocmd!
   autocmd User lsp_buffer_enabled call s:on_lsp_buffer_enabled()
   autocmd BufWritePre <buffer> LspDocumentFormatSync
+  autocmd BufWritePre *.py LspDocumentFormatSync --server=efm-langserver
 augroup END
 
 command! LspDebug let lsp_log_verbose=1 | let lsp_log_file = expand('~/lsp.log')

--- a/roles/vim/.vimrc
+++ b/roles/vim/.vimrc
@@ -269,6 +269,8 @@ augroup LSPSettings
   autocmd BufWritePre <buffer> LspDocumentFormatSync
 augroup END
 
+command! LspDebug let lsp_log_verbose=1 | let lsp_log_file = expand('~/lsp.log')
+
 let g:lsp_signs_enabled = 1
 let g:lsp_diagnostics_echo_cursor = 1
 let g:asyncomplete_auto_popup = 0

--- a/roles/vim/dependencies
+++ b/roles/vim/dependencies
@@ -1,3 +1,4 @@
 homebrew
 fzf
 ripgrep
+efm-lanserver


### PR DESCRIPTION
vim-lsp で、独自のフォーマッター、リンターを有効にする。
通常は、LSP を導入すれば、それに付随したフォーマッターなども自動で機能するので、それを使っていれば良いが、以下のような要件がある場合、独自に設定したくなる。

- ツールを指定されている
- オプション含め、細かく制御したい
- LSP は無いが、リンターだけある

設定に色々とコツ（？）がある。以下のコミットメッセージに詳細を記録している。


- feat: add efm-langserver and python formatter and linter settings
  - efm-langserver をインストールし、config.yaml にフォーマッターなどのツールと、適用する言語のマッピングの設定を記載する。
- feat: add efm-langserver plugin for vim
  - vim-lsp-settings にて、efm-langserver を有効化する（デフォルトは動作しない）。
- feat: add LspDocumentFormatSync --server=efm-langserver
  - オプション）保存したときに、efm-langserver に設定したフォーマッターで、フォーマットする。
- feat: update all Linter and formatter flags in pylsp-all to false
  - efm-langserver の設定のみ効かせたい場合、重複する機能は、LSP 側から OFF にする。

